### PR TITLE
Add video + data load to notebook

### DIFF
--- a/notebooks/00_All_from_Prepopulated.ipynb
+++ b/notebooks/00_All_from_Prepopulated.ipynb
@@ -11,9 +11,29 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Spyglass is a framework for reproducible and shareable neuroscience data analysis. Here, we will demonstrate some featues of spyglass. For the purposes of this demo, an NWB file has been ingested into the position, LFP, and spike sorting pipelines. We will retrieve data from the these pipelines and visualize them together to understand the tuning properties of hippocampal neurons.\n",
+    "Spyglass is a framework for reproducible and shareable neuroscience data analysis.\n",
     "\n",
-    "To learn how this data is loaded, please review the other notebooks in this series.\n"
+    "<div style=\"padding:25% 0 0 0;position:relative;\"><iframe src=\"https://player.vimeo.com/video/922578532?badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479\" frameborder=\"0\" allow=\"autoplay; fullscreen; picture-in-picture; clipboard-write\" style=\"position:absolute;top:0;left:0;width:100%;height:100%;\" title=\"Dr. Loren Frank V4\"></iframe></div><script src=\"https://player.vimeo.com/api/player.js\"></script>\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here, we will demonstrate some featues of spyglass. For the purposes of this demo, we'll directly load a database backup, including position, LFP, and spike sorting data. We will retrieve data from the these pipelines and visualize them together to understand the tuning properties of hippocampal neurons. To learn how this data is loaded with Spyglass in python, please review the other notebooks in this series.\n",
+    "\n",
+    "First, loading the data from a backup on Jupyter Hub:\n",
+    "\n",
+    "<!-- Developer note: once this process is added to the jupyter-hub image, this can remove this line -->\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!mysql -h 127.0.0.1 -u root --password=tutorial < /home/jovyan/shared-readonly/SpyglassPrepopulate.sql"
    ]
   },
   {
@@ -27,7 +47,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "First, we will set up connection to the database. This includes defining information such as the address of the server, the username, and the password. These are contained in `dj_local_conf.json` file.\n"
+    "Next, we will set up connection to the database. This includes defining information such as the address of the server, the username, and the password. These are contained in `dj_local_conf.json` file.\n"
    ]
   },
   {


### PR DESCRIPTION
By adding the data loader to the notebook, we can use the following magic link 

```
https://hhmi.2i2c.cloud/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2FLorenFrankLab%2Fspyglass-demo&urlpath=lab%2Ftree%2Fspyglass-demo%2Fnotebooks%2F00_All_from_Prepopulated.ipynb&branch=main
```

Which was generated from [nbgitpuller](https://nbgitpuller.readthedocs.io/en/latest/link.html) with ...
- JupyterHub URL: https://hhmi.2i2c.cloud/
- Git Repository URL: https://github.com/LorenFrankLab/spyglass-demo
- Branch: main
- File to open: notebooks/00_All_from_Prepopulated.ipynb
- Application to open:  JupyterLab 